### PR TITLE
Implementors of Decodable must implement Sized

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -38,7 +38,7 @@ pub trait Encodable {
 }
 
 /// A trait for objects that can be decoded from slices of bytes.
-pub trait Decodable {
+pub trait Decodable: Sized {
     /// Decodes a slice of bytes and returns an equivalent object.
     ///
     /// If the slice of bytes represents a valid instance of the type, it returns `Ok`, containing


### PR DESCRIPTION
This fixes warnings on rustc 1.4.0-nightly (10d69db0a 2015-08-23) related to
RFC 1214 [0](https://github.com/nikomatsakis/rfcs/blob/projection-and-lifetimes/text/0000-projections-lifetimes-and-wf.md#impact-on-cratesio]).
