### PR TITLE
Fixes libc version on Windows to 0.1.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ nix = "^0.3.8"
 [target.i686-pc-windows-gnu]
 
 [target.i686-pc-windows-gnu.dependencies]
-libc = "*"
+libc = "0.1.12"
 
 [target.i686-unknown-linux-gnu]
 
@@ -48,7 +48,7 @@ nix = "^0.3.8"
 [target.x86_64-pc-windows-gnu]
 
 [target.x86_64-pc-windows-gnu.dependencies]
-libc = "*"
+libc = "0.1.12"
 
 [target.x86_64-unknown-linux-gnu]
 


### PR DESCRIPTION
New version of libc was causing problems on windows CI machines.

https://ci.appveyor.com/project/MaidSafe-QA/crust/build/1.0.363/job/48kj86lentc1x599

```
argo : C:\Users\appveyor\.cargo\registry\src\github.com-121aea75f9ef2ce2\temp_utp-0.6.16\src\with_read_timeout.rs:81:20: 81:32 error: use of undeclared type name `libc::SOCKET` [E0412]
At C:\projects\crust\Build.ps1:12 char:18
+ Invoke-Command { cargo test --no-run --verbose $with_features $release_flag } -N ...
+                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (C:\Users\appvey...SOCKET` [E0412]:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError

C:\Users\appveyor\.cargo\registry\src\github.com-121aea75f9ef2ce2\temp_utp-0.6.16\src\with_read_timeout.rs:81         fd_array: [libc::SOCKET; FD_SETSIZE],
                                                                                                                                 ^~~~~~~~~~~~
```

This PR fixes the libc version to 0.1.12.

A better solution might have been to merge with meqif's master repo where he removes the dependency to `libc` entirely. But that causes quite a big conflicts and I think we should first cleanup our stuff so that meqif has fewer problems merging it himself.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/rust-utp/6)

<!-- Reviewable:end -->
