### PR TITLE
Use VecDeque for buffers instead of Vec.

### DIFF
--- a/benches/socket.rs
+++ b/benches/socket.rs
@@ -2,11 +2,13 @@
 
 extern crate test;
 extern crate utp;
+extern crate rand;
 
 use test::Bencher;
 use utp::UtpSocket;
 use std::sync::Arc;
 use std::thread;
+use std::cmp::min;
 
 macro_rules! iotry {
     ($e:expr) => (match $e { Ok(e) => e, Err(e) => panic!("{}", e) })
@@ -106,3 +108,44 @@ fn bench_transfer_one_megabyte(b: &mut Bencher) {
     });
     b.bytes = len as u64;
 }
+
+#[bench]
+fn bench_transfer_one_megabyte_random_chunks(b: &mut Bencher) {
+    let len = 1024 * 1024;
+    let server_addr = next_test_ip4();
+    let data = (0..len).map(|x| x as u8).collect::<Vec<u8>>();
+    let data_arc = Arc::new(data);
+    let mut received: Vec<u8> = Vec::with_capacity(len);
+
+    b.iter(|| {
+        let data = data_arc.clone();
+        let mut server = iotry!(UtpSocket::bind(server_addr));
+
+        thread::spawn(move || {
+            let mut written_total = 0;
+            let mut client = iotry!(UtpSocket::connect(server_addr));
+            while written_total < len {
+                let chunk_size = rand::random::<u16>() as usize + 1;
+                let chunk_size = min(chunk_size, len - written_total);
+                //println!("written_total == {}; chunk_size == {}", written_total, chunk_size);
+                let written = iotry!(client.send_to(&data[written_total..(written_total + chunk_size)]));
+                written_total += written;
+            }
+            iotry!(client.close());
+        });
+
+        let mut read_total: usize = 0;
+        let mut chunk = [0u8; 65536];
+        while read_total < len {
+            let chunk_size = rand::random::<u16>() as usize + 1;
+            //println!("read_total == {}; chunk_size == {}", read_total, chunk_size);
+            let (read, _) = iotry!(server.recv_from(&mut chunk[..chunk_size]));
+            read_total += read;
+            received.extend(&chunk[..read]);
+        }
+
+        iotry!(server.close());
+    });
+    b.bytes = len as u64;
+}
+

--- a/benches/stream.rs
+++ b/benches/stream.rs
@@ -2,12 +2,14 @@
 
 extern crate test;
 extern crate utp;
+extern crate rand;
 
 use test::Bencher;
 use utp::UtpStream;
 use std::io::{Read, Write};
 use std::sync::Arc;
 use std::thread;
+use std::cmp::min;
 
 macro_rules! iotry {
     ($e:expr) => (match $e { Ok(e) => e, Err(e) => panic!("{}", e) })
@@ -88,3 +90,42 @@ fn bench_transfer_one_megabyte(b: &mut Bencher) {
     });
     b.bytes = len as u64;
 }
+
+#[bench]
+fn bench_transfer_one_megabyte_random_chunks(b: &mut Bencher) {
+    let len = 1024 * 1024;
+    let server_addr = next_test_ip4();
+    let data = (0..len).map(|x| x as u8).collect::<Vec<u8>>();
+    let data_arc = Arc::new(data);
+    let mut received: Vec<u8> = Vec::with_capacity(len);
+
+    b.iter(|| {
+        let data = data_arc.clone();
+        let mut server = iotry!(UtpStream::bind(server_addr));
+
+        thread::spawn(move || {
+            let mut written_total = 0;
+            let mut client = iotry!(UtpStream::connect(server_addr));
+            while written_total < len {
+                let chunk_size = rand::random::<u16>() as usize + 1;
+                let chunk_size = min(chunk_size, len - written_total);
+                let written = iotry!(client.write(&data[written_total..(written_total + chunk_size)]));
+                written_total += written;
+            }
+            iotry!(client.close());
+        });
+
+        let mut read_total = 0;
+        let mut chunk = [0u8; 65536];
+        while read_total < len {
+            let chunk_size = rand::random::<u16>() as usize + 1;
+            let read = iotry!(server.read(&mut chunk[..chunk_size]));
+            read_total += read;
+            received.extend(&chunk[..read]);
+        }
+
+        iotry!(server.close());
+    });
+    b.bytes = len as u64;
+}
+


### PR DESCRIPTION
Also add another benchmark.
This change seems to improve performance slightly (although less than I had expected) but definitely the more sensible way to implement it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/rust-utp/18)

<!-- Reviewable:end -->
