### PR TITLE
Add try_clone methods

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1262,6 +1262,15 @@ impl UtpSocket {
         }
     }
 
+    /// Try and clone the UtpSocket, creating two handles to the same socket that can be used
+    /// concurrently.
+    pub fn try_clone(&self) -> Result<UtpSocket> {
+        Ok(UtpSocket {
+            socket: try!(self.socket.try_clone()),
+            inner: self.inner.clone(),
+        })
+    }
+
     /// Sends every packet in the unsent packet queue.
     fn send(&mut self) -> Result<()> {
         loop {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -96,8 +96,10 @@ fn unsafe_copy(src: &[u8], dst: &mut [u8]) -> usize {
     max_len
 }
 
+/// Stores the internal state of a `UtpSocket`. This can be shared between many `UtpSocket`s using
+/// the `try_clone` method.
 struct UtpSocketInner {
-    /// Remote peer
+    /// The address of the remote peer the socket is connected to.
     connected_to: SocketAddr,
 
     /// Sender connection identifier

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -64,7 +64,7 @@ impl UtpStream {
 
     /// Changes the maximum number of retransmission retries on the underlying socket.
     pub fn set_max_retransmission_retries(&mut self, n: u32) {
-        self.socket.max_retransmission_retries = n;
+        self.socket.set_max_retransmission_retries(n);
     }
 
     /// Try to send a keepalive packet to the peer, ensuring the connection stays active.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -71,6 +71,14 @@ impl UtpStream {
     pub fn send_keepalive(&self) {
         self.socket.send_keepalive();
     }
+
+    /// Try to clone the stream, creating two handles to the same stream that can be used
+    /// concurrently.
+    pub fn try_clone(&self) -> Result<UtpStream> {
+        Ok(UtpStream {
+            socket: try!(self.socket.try_clone()),
+        })
+    }
 }
 
 impl Read for UtpStream {


### PR DESCRIPTION
This splits out the state of a `UtpSocket` into an `Arc<Mutex<_>>` so that multiple `UtpSocket`s can share the same connection.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/rust-utp/20)

<!-- Reviewable:end -->
